### PR TITLE
Mejorar ventana emergente

### DIFF
--- a/views/clipboard_view.py
+++ b/views/clipboard_view.py
@@ -1,13 +1,32 @@
 import tkinter as tk
+from tkinter import ttk
 import pyperclip
 
 class ClipboardView(tk.Tk):
     def __init__(self):
         super().__init__()
         self.title("Historial del Portapapeles")
-        self.listbox = tk.Listbox(self, width=60, height=20)
+        self.configure(bg="white")
+        self.resizable(False, False)
+        self.attributes("-topmost", True)
+
+        # Coloca la ventana cerca del puntero del ratón
+        self.update_idletasks()
+        x, y = self.winfo_pointerxy()
+        self.geometry(f"+{x+10}+{y+10}")
+
+        style = ttk.Style(self)
+        try:
+            style.theme_use("clam")
+        except tk.TclError:
+            pass
+
+        self.listbox = tk.Listbox(self, width=60, height=20, bd=0, highlightthickness=0)
         self.listbox.pack(fill=tk.BOTH, expand=True)
-        self.listbox.bind('<Double-Button-1>', self.on_select)
+        self.listbox.bind("<Double-Button-1>", self.on_select)
+
+        # Cerrar al perder el foco o al hacer clic fuera
+        self.bind("<FocusOut>", lambda e: self.destroy())
 
     def update_list(self, history):
         self.listbox.delete(0, tk.END)


### PR DESCRIPTION
## Summary
- make a popup window appear near the mouse pointer
- close popup when focus is lost
- apply a simple minimalist style

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6841992f5d4083319b97d6dcd94218f1